### PR TITLE
Replace spring-boot-starter-thymeleaf with spring-boot-starter-web

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ repositories {
 
 dependencies {
     compile('org.springframework.boot:spring-boot-starter-data-jpa')
-    compile('org.springframework.boot:spring-boot-starter-thymeleaf')
+    compile('org.springframework.boot:spring-boot-starter-web')
     compile("org.jetbrains.kotlin:kotlin-stdlib-jre8:${kotlinVersion}")
     compile("org.jetbrains.kotlin:kotlin-reflect:${kotlinVersion}")
     testCompile('org.springframework.boot:spring-boot-starter-test')


### PR DESCRIPTION
Thymeleaf is not needed, only its transitive dependency spring-web is
used.