### PR TITLE
Simplify constructors in Service implementations.

### DIFF
--- a/src/main/kotlin/ch/wisv/choice/course/service/CourseServiceImpl.kt
+++ b/src/main/kotlin/ch/wisv/choice/course/service/CourseServiceImpl.kt
@@ -1,14 +1,10 @@
 package ch.wisv.choice.course.service
 
 import ch.wisv.choice.course.model.Course
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class CourseServiceImpl
-
-    @Autowired
-    constructor(@Autowired val courseRepository: CourseRepository) : CourseService {
+class CourseServiceImpl(val courseRepository: CourseRepository) : CourseService {
 
     override fun readAllCourses(): Collection<Course>
             = courseRepository.findAll()

--- a/src/main/kotlin/ch/wisv/choice/document/service/DocumentServiceImpl.kt
+++ b/src/main/kotlin/ch/wisv/choice/document/service/DocumentServiceImpl.kt
@@ -4,19 +4,13 @@ import ch.wisv.choice.course.service.CourseService
 import ch.wisv.choice.document.model.Document
 import ch.wisv.choice.document.model.DocumentDTO
 import ch.wisv.choice.exam.service.ExamService
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 
 @Service
-class DocumentServiceImpl : DocumentService {
-
-    @Autowired
-    lateinit var documentRepository: DocumentRepository
-    @Autowired
-    lateinit var examService: ExamService
-    @Autowired
-    lateinit var courseService: CourseService
+class DocumentServiceImpl(val documentRepository: DocumentRepository,
+                          val examService: ExamService,
+                          val courseService: CourseService) : DocumentService {
 
     override fun storeDocument(file: MultipartFile, dto: DocumentDTO) {
         val doc = Document(file = file, name = dto.name, exam = dto.exam)

--- a/src/main/kotlin/ch/wisv/choice/exam/service/ExamServiceImpl.kt
+++ b/src/main/kotlin/ch/wisv/choice/exam/service/ExamServiceImpl.kt
@@ -1,14 +1,10 @@
 package ch.wisv.choice.exam.service
 
 import ch.wisv.choice.exam.model.Exam
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class ExamServiceImpl
-
-    @Autowired
-    constructor(@Autowired val examRepository: ExamRepository) : ExamService {
+class ExamServiceImpl(val examRepository: ExamRepository) : ExamService {
 
     override fun createExam(exam: Exam): Exam
             = examRepository.saveAndFlush(exam)


### PR DESCRIPTION
In Spring 4.3, if a bean has one constructor, you can omit the @Autowired.
In Kotlin, if the primary constructor has no annotations or visibility modifiers, the constructor keyword can be omitted.