### PR TITLE
Fix links to pages causing some browsers to route to a 404

### DIFF
--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -66,19 +66,19 @@
                     <div class="row">
 
                         <div class="col-md-4 text-center main-button">
-                            <a href="./courses/">
+                            <a href="courses/">
                                 <i class="fa fa-5x fa-book"></i> <br>
                                 <span>Courses</span>
                             </a>
                         </div>
                         <div class="col-md-4 text-center main-button">
-                            <a href="./exams/create/">
+                            <a href="exams/create/">
                                 <i class="fa fa-5x fa-plus"></i> <br>
                                 <span>Add exam</span>
                             </a>
                         </div>
                         <div class="col-md-4 text-center main-button">
-                            <a href="./exams/">
+                            <a href="exams/">
                                 <i class="fa fa-5x fa-file-text"></i> <br>
                                 <span>View exams</span>
                             </a>


### PR DESCRIPTION
For some reason, on some browsers (depending on the machine used too) the `./` caused routing to the root domain without the `/dashboard` part.