### PR TITLE
Fix course filtering when study or studyProgram is null

### DIFF
--- a/src/main/kotlin/ch/wisv/choice/course/controller/CourseController.kt
+++ b/src/main/kotlin/ch/wisv/choice/course/controller/CourseController.kt
@@ -80,13 +80,13 @@ class CourseController(val courseService: CourseService, val examService: ExamSe
             if (request.getParameter("study") != null && request.getParameter("study") != "") {
                 val studyEnum = Study.valueOf(request.getParameter("study"))
 
-                courses = courses.filter { item -> item.study!! == studyEnum }
+                courses = courses.filter { item -> item.study == studyEnum }
             }
 
             if (request.getParameter("program") != null && request.getParameter("program") != "") {
                 val studyProgramEnum = StudyProgram.valueOf(request.getParameter("program"))
 
-                courses = courses.filter { item -> item.studyProgram!! == studyProgramEnum }
+                courses = courses.filter { item -> item.studyProgram == studyProgramEnum }
             }
         } catch (e: IllegalArgumentException) {
             return createResponseEntity(HttpStatus.BAD_REQUEST, "Invalid study or program input.")


### PR DESCRIPTION
The last added exam (WI2411TU, id 3887) has a study with value null. This causes errors.

{"code":"WI1105IN","name":"Lineaire algebra","predecessor":null,"study":"CS","studyProgram":"FIRST_YEAR"},"date":"2009-08-24","includingAnswers":false,"name":"Exam"}]},{"code":"WI2411TU","name":"Financial Time Series","predecessor":null,"study":null,"studyProgram":"MINOR","exam":[{"id":3887,"course":{"code":"WI2411TU","name":"Financial Time Series","predecessor":null,"study":null,"studyProgram":"MINOR"},"date":"2020-11-05","includingAnswers":false,"name":"Exam"}]}